### PR TITLE
ci(publish): build linux/amd64 exclusively

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,6 @@ jobs:
           context: ./${{ steps.dockerfile.outputs.subdir }}
           platforms: |
             linux/amd64
-            linux/arm64
           push: true
           tags: |
             coatldev/six:${{ github.event.release.tag_name }}


### PR DESCRIPTION
having both amd64 and arm64 is taking between two to four hours
building only for amd64 will reduce workflow running time