### PR TITLE
ci(push): enable latest and major tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,19 @@ jobs:
         id: dockerfile
         run: echo "subdir=$(echo ${{ github.event.release.tag_name }} | cut -d '.' -f 1,2)" >> $GITHUB_OUTPUT
 
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            coatldev/six
+          tags: |
+            type=pep440,pattern={{version}}
+            type=pep440,pattern={{major}}.{{minor}}
+            # set major and latest tag only for latest stable release
+            type=pep440,pattern={{major}},enable=${{ startsWith(github.ref, 'refs/tags/3.11.') }}
+            type=pep440,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/3.11.') }}
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -32,8 +45,6 @@ jobs:
           platforms: |
             linux/amd64
           push: true
-          tags: |
-            coatldev/six:${{ github.event.release.tag_name }}
-            coatldev/six:${{ steps.dockerfile.outputs.subdir }}
+          tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,6 @@ repos:
     hooks:
       - id: hadolint
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: 3.8.2
+    rev: 3.9.0
     hooks:
     - id: commitizen

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Docker image based on Ubuntu 22.04 (Jammy Jellyfish) with Python 2.7 and Python 
 
 - `3.12`, `3.12.0rc2` - Comes with Python 3.12.0rc2 and 2.7.18.
 - `3.11`, `3.11.5` - Comes with Python 3.11.5 and 2.7.18.
-- `3.10.13`, `latest` - Comes with Python 3.10.13 and 2.7.18.
+- `3.10`, `3.10.13`, `latest` - Comes with Python 3.10.13 and 2.7.18.
 - `3.10.12` - Comes with Python 3.10.12 and 2.7.18.
 - `3.10.11` - Comes with Python 3.10.11 and 2.7.18.
 


### PR DESCRIPTION
these tags will be enabled only for the latest Python stable release