### PR TITLE
ci(publish): run only when changes have been made to Dockerfile on the coatl branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,9 @@ name: publish
 on:
   push:
     branches:
-      - coatl
+      - 'coatl'
+    paths:
+      - 'Dockerfile'
 
 env:
   REGISTRY_IMAGE: coatldev/six

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,5 @@
 ci:
   autoupdate_commit_msg: 'build(deps): pre-commit autoupdate'
-  autoupdate_branch: 'dev'
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
allow pre-commit.ci to create a PR against the coatl branch
