### PR TITLE
bump: setuptools from 70.1.1 to 70.2.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,8 +58,8 @@ jobs:
         id: build
         uses: docker/build-push-action@v6
         with:
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,scope=${{ matrix.platform }},mode=max
           context: .
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           platforms: ${{ matrix.platform }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -250,7 +250,7 @@ RUN set -eux; \
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION=24.1.1
-ENV PYTHON_SETUPTOOLS_VERSION=70.1.1
+ENV PYTHON_SETUPTOOLS_VERSION=70.2.0
 ENV PYTHON_WHEEL_VERSION=0.43.0
 # https://github.com/pypa/get-pip
 ENV PYTHON_GET_PIP_URL=https://raw.githubusercontent.com/pypa/get-pip/HEAD/public/get-pip.py


### PR DESCRIPTION
ci:
- use scope option for caching Docker builds
