### PR TITLE
ci(publish): keep cache alive

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - '.github/workflows/publish.yml'
       - 'Dockerfile'
+  schedule:
+    - cron: '0 0 * * 1,5'
 
 env:
   REGISTRY_IMAGE: coatldev/six
@@ -66,15 +68,15 @@ jobs:
 
       - name: Export digest
         run: |
-          mkdir -p /tmp/python-digests
+          mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/python-digests/${digest#sha256:}"
+          touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
-          path: /tmp/python-digests/*
+          path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
 
@@ -99,7 +101,7 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
-          path: /tmp/python-digests
+          path: /tmp/digests
           pattern: digests-*
           merge-multiple: true
 
@@ -114,9 +116,7 @@ jobs:
           tags: |
             type=raw,value=${{ needs.build.outputs.version }}
             type=raw,value=${{ needs.build.outputs.major_minor }}
-            type=raw,value={{date 'YYYYMMDD'}}
             type=raw,value=latest,enable={{is_default_branch}}
-            type=sha,prefix=sha-
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -125,7 +125,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Create manifest list and push
-        working-directory: /tmp/python-digests
+        working-directory: /tmp/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ jobs:
         displayName: Change owner
 
       - script: |
-          python -m pip install --upgrade tox
+          python -m pip install tox
         displayName: Install dependencies
 
       - script: |
@@ -62,7 +62,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade tox
+          python -m pip install tox
 
       - name: Run tests
         run: |


### PR DESCRIPTION
building arm64 on amd64 takes 3h30m on average without caching
this should reduce build times if there has been no update to:
- Python
- pip
- setuptools
- wheel
