### PR TITLE
ci(auto-update): update Python version automatically

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -3,6 +3,7 @@ name: auto-update
 on:
   schedule:
     - cron: '0 20 * * 0'
+    - cron: '0 18 10 2-12/2 *'
   workflow_dispatch:
 
 jobs:
@@ -11,6 +12,15 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+
+      - name: Fetch latest Python 3.12 release
+        if: github.event.schedule == '0 18 10 2-12/2 *'
+        run: |
+          python3_version=$(curl -s https://www.python.org/ftp/python/ | grep -oP '3\.12\.\d+/' | uniq | sort -V | tail -n 1 | tr -d '/')
+
+          echo "python312: $python3_version"
+
+          sed -i "s/ENV PYTHON3_VERSION=.*/ENV PYTHON3_VERSION=$python3_version/" Dockerfile
 
       - name: Update requirements
         uses: coatl-dev/actions/pip-compile@v3

--- a/README.md
+++ b/README.md
@@ -2,15 +2,14 @@
 
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/coatl-dev/docker-six/coatl.svg)](https://results.pre-commit.ci/latest/github/coatl-dev/docker-six/coatl)
 [![Docker Pulls](https://img.shields.io/docker/pulls/coatldev/six)](https://hub.docker.com/r/coatldev/six)
+[![Docker Repository on Quay](https://quay.io/repository/coatldev/six/status "Docker Repository on Quay")](https://quay.io/repository/coatldev/six)
 
 Docker image based on Ubuntu 24.04 (Noble Numbat) with Python 3.12 and 2.7.18
 pre-installed.
 
 ## Supported tags
 
-- [`3.12`, `3.12.4`, `latest`] - Comes with Python 3.12.4 and 2.7.18.
-
-For more tags, [click here].
+For the full list of supported tags, [click here].
 
 ## How to use this image
 


### PR DESCRIPTION
follow Python 3.12 release schedule
See: https://peps.python.org/pep-0693/#bugfix-releases
