### PR TITLE
refactor: install git runtime dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,19 +29,22 @@ RUN set -eux; \
         build-essential \
         bzip2 \
         ca-certificates \
-        cdbs \
         curl \
-        debhelper \
-        expat \
         gcc \
+        git-man \
+        libc6 \
         libcurl3t64-gnutls \
-        libcurl4t64 \
+        liberror-perl \
+        libexpat1 \
+        libpcre2-8-0 \
         make \
         netbase \
         openssl \
+        perl \
         sudo \
         tzdata \
         wget \
+        zlib1g \
     ; \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
$ apt-cache depends git
git
  Depends: libc6
  Depends: libcurl3t64-gnutls
  Depends: libexpat1
  Depends: libpcre2-8-0
  Depends: zlib1g
  Depends: perl
  Depends: liberror-perl
  Depends: git-man
