### PR TITLE
refactor(apt): remove iproute2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ RUN set -eux; \
         ca-certificates \
         curl \
         git-man \
-        iproute2 \
         less \
         libcurl3t64-gnutls \
         liberror-perl \


### PR DESCRIPTION
this was added because it was needed inside a devcontainer
this is not part of the core packages on this image
